### PR TITLE
feat: Implement dark mode and light mode toggle

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,1 +1,11 @@
-<div>{{title}}</div>
+<div [ngClass]="{'dark-mode': isDarkMode}">
+  <div class="theme-switcher">
+    <button (click)="toggleTheme()">
+      {{ isDarkMode ? 'Light Mode' : 'Dark Mode' }}
+    </button>
+  </div>
+  <div class="content">
+    <h1>Welcome to {{ title }}!</h1>
+    <p>This is a simple demo of dark and light mode in an Angular application.</p>
+  </div>
+</div>

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -1,0 +1,24 @@
+.theme-switcher {
+  display: flex;
+  justify-content: flex-end;
+  padding: 1rem;
+
+  button {
+    background-color: var(--button-bg-color);
+    color: var(--button-text-color);
+    border: 1px solid var(--text-color);
+    padding: 0.5rem 1rem;
+    cursor: pointer;
+    border-radius: 5px;
+    transition: background-color 0.3s, color 0.3s;
+
+    &:hover {
+      opacity: 0.8;
+    }
+  }
+}
+
+.content {
+  padding: 2rem;
+  text-align: center;
+}

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,12 +1,41 @@
-import { Component } from '@angular/core';
+import { Component, Renderer2, OnInit, Inject, PLATFORM_ID } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
 import { RouterOutlet } from '@angular/router';
+import { CommonModule } from '@angular/common';
 
 @Component({
   selector: 'app-root',
-  imports: [RouterOutlet],
+  imports: [RouterOutlet, CommonModule],
   templateUrl: './app.component.html',
   styleUrl: './app.component.scss'
 })
-export class AppComponent {
+export class AppComponent implements OnInit {
   title = 'jules-demo';
+  isDarkMode = false;
+
+  constructor(
+    private renderer: Renderer2,
+    @Inject(PLATFORM_ID) private platformId: Object
+  ) {}
+
+  ngOnInit() {
+    if (isPlatformBrowser(this.platformId)) {
+      this.updateTheme();
+    }
+  }
+
+  toggleTheme() {
+    this.isDarkMode = !this.isDarkMode;
+    this.updateTheme();
+  }
+
+  private updateTheme() {
+    if (isPlatformBrowser(this.platformId)) {
+      if (this.isDarkMode) {
+        this.renderer.addClass(document.body, 'dark-mode');
+      } else {
+        this.renderer.removeClass(document.body, 'dark-mode');
+      }
+    }
+  }
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,1 +1,20 @@
-/* You can add global styles to this file, and also import other style files */
+:root {
+  --background-color: #ffffff;
+  --text-color: #000000;
+  --button-bg-color: #f0f0f0;
+  --button-text-color: #000000;
+}
+
+body {
+  background-color: var(--background-color);
+  color: var(--text-color);
+  font-family: Arial, sans-serif;
+  transition: background-color 0.3s, color 0.3s;
+}
+
+body.dark-mode {
+  --background-color: #121212;
+  --text-color: #ffffff;
+  --button-bg-color: #333333;
+  --button-text-color: #ffffff;
+}


### PR DESCRIPTION
This commit introduces a dark mode and light mode toggling feature to the application.

- A button has been added to the `AppComponent` to allow users to switch between light and dark themes.
- The theme state is managed within the `AppComponent` and a `dark-mode` class is applied to the `body` element when dark mode is active.
- Global styles have been updated to use CSS variables for theming, with separate color palettes for light and dark modes.
- The component-specific styles have been updated to use the new theme variables.
- The implementation is server-side rendering (SSR) compatible by using `isPlatformBrowser` to ensure DOM manipulation only happens on the client-side.